### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Nia Codebase MCP server allows you to integrate with Nia's codebase understanding capabilities through function calling in tools like Cursor, Claude Desktop, and other MCP-compatible clients.
 
+<a href="https://glama.ai/mcp/servers/@nozomio-labs/nia-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nozomio-labs/nia-mcp/badge" alt="Nia Codebase MCP server" />
+</a>
+
 ## Installation
 
 You can use this MCP server without installing it using npx:


### PR DESCRIPTION
This PR adds a badge for the [Nia Codebase MCP](https://glama.ai/mcp/servers/@nozomio-labs/nia-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@nozomio-labs/nia-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@nozomio-labs/nia-mcp/badge" alt="Nia Codebase MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.